### PR TITLE
Implement configuration for HTTPS scheme behind reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Optional variables:
     Use this variables to config confluence behind a proxy server
 - `confluence_proxy.public_port` sets the public port
 - `confluence_proxy.public_domain` sets the public domain
+- `confluence_proxy.secure` uses HTTPS reverse proxy if true, otherwise HTTP.
 
 # Testing
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ Optional variables:
 - `confluence_proxy.public_port` sets the public port
 - `confluence_proxy.public_domain` sets the public domain
 - `confluence_proxy.secure` uses HTTPS reverse proxy if true, otherwise HTTP.
+- `confluence_proxy.additionalParameters` sets additional parameters of connector
+    configuration.
+    For example relaxedPathChars/relaxedQueryChars as documented in https://confluence.atlassian.com/kb/samplehttpconnector-753893891.html
 
 # Testing
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,7 @@ confluence_proxy:
   public_port: ''
   public_domain: ''
   secure: false
+  additionalParameters: 'relaxedPathChars="[]|" relaxedQueryChars="[]|{}^&#x5c;&#x60;&quot;&lt;&gt;"'
 
 confluence_jdbc_install: no
 confluence_jdbc_origin: ''

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,6 +50,7 @@ confluence_catalina_opts:
   - "${START_CONFLUENCE_JAVA_OPTS}"
   - "-Dconfluence.context.path=${CONFLUENCE_CONTEXT_PATH}"
   - "-XX:ReservedCodeCacheSize=256m -XX:+UseCodeCacheFlushing"
+  - "-XX:+IgnoreUnrecognizedVMOptions"
 
 confluence_logrotate_enabled: true
 confluence_logrotate_config_file: templates/confluence.j2

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,7 @@ confluence_proxy_enabled: no
 confluence_proxy:
   public_port: ''
   public_domain: ''
+  secure: false
 
 confluence_jdbc_install: no
 confluence_jdbc_origin: ''

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,3 +3,9 @@
   hosts: confluence_group
   roles:
     - role: confluence_role
+      vars:
+        confluence_proxy_enabled: yes
+        confluence_proxy:
+          public_domain: 'localhost'
+          public_port: 443
+          secure: true

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -9,3 +9,4 @@
           public_domain: 'localhost'
           public_port: 443
           secure: true
+          additionalParameters: 'relaxedPathChars="[]|" relaxedQueryChars="[]|{}^&#x5c;&#x60;&quot;&lt;&gt;"'

--- a/templates/server.xml.j2
+++ b/templates/server.xml.j2
@@ -84,6 +84,20 @@
                     <!-- Logging configuration for Confluence is specified in confluence/WEB-INF/classes/log4j.properties -->
                     <Manager pathname=""/>
                     <Valve className="org.apache.catalina.valves.StuckThreadDetectionValve" threshold="60"/>
+
+                    <!-- http://tomcat.apache.org/tomcat-9.0-doc/config/valve.html#Access_Log_Valve -->
+                    <Valve className="org.apache.catalina.valves.AccessLogValve"
+                           directory="logs"
+                           maxDays="30"
+                           pattern="%t %{X-AUSERNAME}o %I %h %r %s %Dms %b %{Referer}i %{User-Agent}i"
+                           prefix="conf_access_log"
+                           requestAttributesEnabled="true"
+                           rotatable="true"
+                           suffix=".log"
+                    />
+
+                    <!-- http://tomcat.apache.org/tomcat-9.0-doc/config/valve.html#Remote_IP_Valve -->
+                    <Valve className="org.apache.catalina.valves.RemoteIpValve" />
                 </Context>
 
                 <Context path="${confluence.context.path}/synchrony-proxy" docBase="../synchrony-proxy" debug="0"

--- a/templates/server.xml.j2
+++ b/templates/server.xml.j2
@@ -9,12 +9,15 @@
         -->
 
 {% if confluence_proxy_enabled %}
+<!--
+{% endif %}
         <Connector port="{{ confluence_connector_port }}" connectionTimeout="20000" redirectPort="8443"
                    maxThreads="48" minSpareThreads="10"
                    enableLookups="false" acceptCount="10" debug="0" URIEncoding="UTF-8"
-                   protocol="org.apache.coyote.http11.Http11NioProtocol"
-                   scheme="http" proxyName="{{ confluence_proxy['public_domain'] }}" proxyPort="{{ confluence_proxy['public_port'] }}"/>
+                   protocol="org.apache.coyote.http11.Http11NioProtocol"/>
 
+{% if confluence_proxy_enabled %}
+-->
 {% endif %}
 
         <!--
@@ -31,14 +34,17 @@
          ==============================================================================================================
         -->
 
+{% if not confluence_proxy_enabled or (confluence_proxy_enabled and confluence_proxy.secure) %}
         <!--
-        <Connector port="8090" connectionTimeout="20000" redirectPort="8443"
+{% endif %}
+        <Connector port="{{ confluence_connector_port }}" connectionTimeout="20000" redirectPort="8443"
                    maxThreads="48" minSpareThreads="10"
                    enableLookups="false" acceptCount="10" debug="0" URIEncoding="UTF-8"
                    protocol="org.apache.coyote.http11.Http11NioProtocol"
-                   scheme="http" proxyName="<subdomain>.<domain>.com" proxyPort="80"/>
+                   scheme="http" proxyName="{{ confluence_proxy.public_domain }}" proxyPort="{{ confluence_proxy.public_port }}"/>
+{% if not confluence_proxy_enabled or (confluence_proxy_enabled and confluence_proxy.secure) %}
         -->
-        
+{% endif %}
         <!--
          ==============================================================================================================
          HTTPS - Direct connector with no proxy, for unproxied HTTPS access to Confluence.
@@ -70,13 +76,17 @@
          ==============================================================================================================
         -->
 
+{% if not confluence_proxy_enabled or (confluence_proxy_enabled and not confluence_proxy.secure) %}
         <!--
-        <Connector port="8090" connectionTimeout="20000" redirectPort="8443"
+{% endif %}
+        <Connector port="{{ confluence_connector_port }}" connectionTimeout="20000" redirectPort="8443"
                    maxThreads="48" minSpareThreads="10"
                    enableLookups="false" acceptCount="10" debug="0" URIEncoding="UTF-8"
                    protocol="org.apache.coyote.http11.Http11NioProtocol"
-                   scheme="https" secure="true" proxyName="<subdomain>.<domain>.com" proxyPort="443"/>
+                   scheme="https" secure="true" proxyName="{{ confluence_proxy.public_domain }}" proxyPort="{{ confluence_proxy.public_port }}"/>
+{% if not confluence_proxy_enabled or (confluence_proxy_enabled and not confluence_proxy.secure) %}
         -->
+{% endif %}
 
         <Engine name="Standalone" defaultHost="localhost" debug="0">
             <Host name="localhost" debug="0" appBase="webapps" unpackWARs="true" autoDeploy="false" startStopThreads="4">

--- a/templates/server.xml.j2
+++ b/templates/server.xml.j2
@@ -41,6 +41,7 @@
                    maxThreads="48" minSpareThreads="10"
                    enableLookups="false" acceptCount="10" debug="0" URIEncoding="UTF-8"
                    protocol="org.apache.coyote.http11.Http11NioProtocol"
+                   {{ confluence_proxy.additionalParameters }}
                    scheme="http" proxyName="{{ confluence_proxy.public_domain }}" proxyPort="{{ confluence_proxy.public_port }}"/>
 {% if not confluence_proxy_enabled or (confluence_proxy_enabled and confluence_proxy.secure) %}
         -->
@@ -83,6 +84,7 @@
                    maxThreads="48" minSpareThreads="10"
                    enableLookups="false" acceptCount="10" debug="0" URIEncoding="UTF-8"
                    protocol="org.apache.coyote.http11.Http11NioProtocol"
+                   {{ confluence_proxy.additionalParameters }}
                    scheme="https" secure="true" proxyName="{{ confluence_proxy.public_domain }}" proxyPort="{{ confluence_proxy.public_port }}"/>
 {% if not confluence_proxy_enabled or (confluence_proxy_enabled and not confluence_proxy.secure) %}
         -->


### PR DESCRIPTION
### Description of the Change

This change does the following things:
- Synchronizes backwards-compatible modifications of original configuration files of version 7.13.7, which fixes also the problem, that confluence would not start with more recent JRE 
- Implements possibility to have Confluence behind a HTTPS reverse proxy. Reorganize the template changes in server.xml in a way, that HTTP without reverse proxy, HTTP/HTTPS with reverse proxy all are possible by setting configuration accordingly. The modification is done in a way, that the outcome of the generated config file differs as less as possible from original file, in order that it is easily possible to do a diff.
- Adds possibility to have additional parameters in Connector configuration in order to be able to configure relaxedPathChars/relaxedQueryChars as documented in https://confluence.atlassian.com/kb/samplehttpconnector-753893891.html

### Benefits

- HTTPS is possible
- newer JRE are possible

